### PR TITLE
Make the bound value more perdictable.

### DIFF
--- a/angular-file-model.js
+++ b/angular-file-model.js
@@ -21,7 +21,7 @@
 
           element.bind('change', function(){
             scope.$apply(function(){
-              if (element[0].files.length > 1) {
+              if (attrs.multiple) {
                 modelSetter(scope, element[0].files);
               }
               else {


### PR DESCRIPTION
If the file input is set to multiple, always bind an array. If it's not set to multiple is gets the single file.
