### PR TITLE
Use default angular ngModel

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,3 +3,9 @@
 
  * Renamed module to just `file-model` (Fixes #2)
  * basic test file
+
+0.4.0 / 2018-01-10 
+==================
+
+ * Use default angular ngModel
+ * Set model Validity

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Ready to use in your controllers!:
 
 `file.html`:
 
-    <input type='file' file-model='fileModel'>
+    <input type='file' file-model ng-model='fileModel'>
     <button type='button' ng-click='upload()'>Upload</button>
 
 `controller.js:`

--- a/angular-file-model.js
+++ b/angular-file-model.js
@@ -10,28 +10,27 @@
 
   angular.module('file-model', [])
 
-  .directive('fileModel', [
-    '$parse',
-    function ($parse) {
+  .directive('fileModel', function () {
       return {
+	require: 'ngModel',
         restrict: 'A',
-        link: function(scope, element, attrs) {
-          var model = $parse(attrs.fileModel);
-          var modelSetter = model.assign;
+        link: function($scope, element, attrs, ngModel) {
+          var checkIsValid = function(){
+            ngModel.$setValidity('validFile', element.val() !=='');
+       	  };
+        
+          checkIsValid();
 
-          element.bind('change', function(){
-            scope.$apply(function(){
-              if (attrs.multiple) {
-                modelSetter(scope, element[0].files);
-              }
-              else {
-                modelSetter(scope, element[0].files[0]);
-              }
+          element.bind('change', function () {
+            $scope.$apply(function () {
+                checkIsValid();
+                ngModel.$setViewValue(attrs.multiple ? element[0].files : element[0].files[0]);
+                ngModel.$render();
             });
           });
         }
       };
     }
-  ]);
+  );
 
 })();

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,10 @@
 {
   "name": "angular-file-model",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "authors": [
     "Jose Luis Rivas <me@ghostbar.co>",
-    "Paul-Louis Nech <github@plnech.fr>"
+    "Paul-Louis Nech <github@plnech.fr>",
+    "Marc Mascort Bou <marc@articstudio.com>"
   ],
   "description": "Angular support for file in models",
   "main": "angular-file-model.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-file-model",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Angular support for file in models",
   "main": "angular-file-model.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -17,7 +17,7 @@ describe('angular-file-model directive', function () {
 
   it('', function () {
     $rootScope.fileModel = '';
-    var element = $compile('<input type=\'file\' file-model=\'fileModel\'>')
+    var element = $compile('<input type=\'file\' file-model ng-model=\'fileModel\'>')
     ($rootScope);
     $rootScope.$digest();
     console.log($rootScope.fileModel);


### PR DESCRIPTION
With this change is more simple to use, and add model validity.
It's necessary edit README:
 - Example/Demo
 - Know issue

New usage:
`<input type='file' file-model ng-model='fileModel'>`

  